### PR TITLE
Environment is not loaded when using Mongoid and accessing sub-seed

### DIFF
--- a/lib/seedbank/dsl.rb
+++ b/lib/seedbank/dsl.rb
@@ -13,7 +13,7 @@ module Seedbank
     def seed_task_from_file(seed_file)
       scopes  = scope_from_seed_file(seed_file)
       fq_name = scopes.push(File.basename(seed_file, '.seeds.rb')).join(':')
-      args    = Rake::Task.task_defined?('db:abort_if_pending_migrations') ? { fq_name => 'db:abort_if_pending_migrations' } : fq_name
+      args    = Rake::Task.task_defined?('db:abort_if_pending_migrations') ? { fq_name => 'db:abort_if_pending_migrations' } : { fq_name => :environment }
 
       define_seed_task(seed_file, args)
     end


### PR DESCRIPTION
Say we have this task `db:seed:admins` and we're using Mongoid (>= 3.0.0), we run and it throws an error like `uninitialized constant <ModelName>` and aborts. Running `db:seed` runs fine though.

This seems related to issue #5.
