### PR TITLE
Changed filenaming convention from .seeds.rb to _seeds.rb

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,30 +17,30 @@ Example
 Seedbank seeds follow this structure;
 
     db/seeds/
-      bar.seeds.rb
+      bar_seeds.rb
       development/
-        users.seeds.rb
-      foo.seeds.rb
+        users_seeds.rb
+      foo_seeds.rb
 
 This would generate the following Rake tasks
 
-    rake db:seed                    # Load the seed data from db/seeds.rb, db/seeds/*.seeds.rb and db/seeds/ENVIRONMENT/*.seeds.rb. ENVIRONMENT is the current environment in Rails.env.
-    rake db:seed:bar                # Load the seed data from db/seeds/bar.seeds.rb
-    rake db:seed:common             # Load the seed data from db/seeds.rb and db/seeds/*.seeds.rb.
-    rake db:seed:development        # Load the seed data from db/seeds.rb, db/seeds/*.seeds.rb and db/seeds/development/*.seeds.rb.
-    rake db:seed:development:users  # Load the seed data from db/seeds/development/users.seeds.rb
-    rake db:seed:foo                # Load the seed data from db/seeds/foo.seeds.rb
+    rake db:seed                    # Load the seed data from db/seeds.rb, db/seeds/*_seeds.rb and db/seeds/ENVIRONMENT/*_seeds.rb. ENVIRONMENT is the current environment in Rails.env.
+    rake db:seed:bar                # Load the seed data from db/seeds/bar_seeds.rb
+    rake db:seed:common             # Load the seed data from db/seeds.rb and db/seeds/*_seeds.rb.
+    rake db:seed:development        # Load the seed data from db/seeds.rb, db/seeds/*_seeds.rb and db/seeds/development/*_seeds.rb.
+    rake db:seed:development:users  # Load the seed data from db/seeds/development/users_seeds.rb
+    rake db:seed:foo                # Load the seed data from db/seeds/foo_seeds.rb
     rake db:seed:original           # Load the seed data from db/seeds.rb
 
 Therefor assuming RAILS_ENV is not set or is 'development'
 
     $ rake db:seed
 
-would load the seeds in db/seeds.rb, db/seeds/bar.seeds.rb, db/seeds/foo.seeds/rb and db/seeds/development/users.seeds.rb. Whereas
+would load the seeds in db/seeds.rb, db/seeds/bar_seeds.rb, db/seeds/foo.seeds/rb and db/seeds/development/users_seeds.rb. Whereas
 
     $ RAILS_ENV=production db:seed
 
-would load the seeds in db/seeds.rb, db/seeds/bar.seeds.rb and db/seeds/foo.seeds/rb
+would load the seeds in db/seeds.rb, db/seeds/bar_seeds.rb and db/seeds/foo.seeds/rb
 
 Installation
 ============
@@ -81,7 +81,7 @@ Usage
 
 Seeds files are just plain old Ruby executed in your rails application environment so anything you could type into the rails console will work in your seeds.
 
-db/seeds/companies.seeds.rb
+db/seeds/companies_seeds.rb
 ```ruby
 Company.find_or_create_by_name('Hatch', :url => 'http://thisishatch.co.uk' )
 ```
@@ -89,7 +89,7 @@ Company.find_or_create_by_name('Hatch', :url => 'http://thisishatch.co.uk' )
 The seed files under db/seeds are run first in alphanumeric order followed by the ones in the db/seeds/RAILS_ENV. You can add dependencies to your seed files
 to enforce the run order. for example;
 
-db/seeds/users.seeds.rb
+db/seeds/users_seeds.rb
 ```ruby
 after :companies do
   company = Company.find_by_name('Hatch')
@@ -97,7 +97,7 @@ after :companies do
 end
 ```
 
-db/seeds/projects.seeds.rb
+db/seeds/projects_seeds.rb
 ```ruby
 after :companies do
   company = Company.find_by_name('Hatch')
@@ -105,7 +105,7 @@ after :companies do
 end
 ```
 
-db/seeds/tasks.seeds.rb
+db/seeds/tasks_seeds.rb
 ```ruby
 after :projects, :users do
   project = Project.find_by_name('Seedbank')
@@ -116,7 +116,7 @@ end
 
 If the dependencies are in one of the environment folders, you need to namespace the parent task:
 
-db/seeds/development/users.seeds.rb
+db/seeds/development/users_seeds.rb
 ```ruby
 after "development:companies" do
   company = Company.find_by_name('Hatch')
@@ -135,6 +135,7 @@ git log | grep Author | sort | uniq
 * Philip Arndt
 * Peter Suschlik
 * Joost Baaij
+* Stan Carver II
 
 Note on Patches/Pull Request
 ============================

--- a/README.md
+++ b/README.md
@@ -1,7 +1,4 @@
-Seedbank
-
-[![Build Status](https://secure.travis-ci.org/statique/seedbank.png)](http://travis-ci.org/statique/seedbank) [![Dependency Status](https://gemnasium.com/statique/seedbank.png)](https://gemnasium.com/statique/seedbank)
-
+Seedbank [![Build Status](https://secure.travis-ci.org/statique/seedbank.png)](http://travis-ci.org/statique/seedbank) [![Dependency Status](https://gemnasium.com/statique/seedbank.png)](https://gemnasium.com/statique/seedbank)
 ========
 
 Seedbank allows you to structure your Rails seed data instead of having it all dumped into one large file. I find my seed data tended to fall into two categories. 1. Stuff that the entire application requires. 2. Stuff to populate my development and staging environments.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
 Seedbank
+
++[![Build Status](https://secure.travis-ci.org/statique/seedbank.png)](http://travis-ci.org/statique/seedbank) [![Dependency Status](https://gemnasium.com/statique/seedbank.png)](https://gemnasium.com/statique/seedbank)
+
 ========
 
 Seedbank allows you to structure your Rails seed data instead of having it all dumped into one large file. I find my seed data tended to fall into two categories. 1. Stuff that the entire application requires. 2. Stuff to populate my development and staging environments.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 Seedbank
 
-+[![Build Status](https://secure.travis-ci.org/statique/seedbank.png)](http://travis-ci.org/statique/seedbank) [![Dependency Status](https://gemnasium.com/statique/seedbank.png)](https://gemnasium.com/statique/seedbank)
+[![Build Status](https://secure.travis-ci.org/statique/seedbank.png)](http://travis-ci.org/statique/seedbank) [![Dependency Status](https://gemnasium.com/statique/seedbank.png)](https://gemnasium.com/statique/seedbank)
 
 ========
 

--- a/lib/seedbank/dsl.rb
+++ b/lib/seedbank/dsl.rb
@@ -13,7 +13,7 @@ module Seedbank
     def seed_task_from_file(seed_file)
       scopes  = scope_from_seed_file(seed_file)
       fq_name = scopes.push(File.basename(seed_file, '_seeds.rb')).join(':')
-      args    = Rake::Task.task_defined?('db:abort_if_pending_migrations') ? { fq_name => 'db:abort_if_pending_migrations' } : fq_name
+      args    = Rake::Task.task_defined?('db:abort_if_pending_migrations') ? { fq_name => 'db:abort_if_pending_migrations' } : { fq_name => :environment }
 
       define_seed_task(seed_file, args)
     end
@@ -24,7 +24,7 @@ module Seedbank
 
     def define_seed_task(seed_file, *args)
       task = Rake::Task.define_task(*args) do |seed_task|
-        Seedbank::Runner.new(seed_task).module_eval(File.read(seed_file)) if File.exist?(seed_file)
+        Seedbank::Runner.new(seed_task).module_eval(File.read(seed_file), seed_file) if File.exist?(seed_file)
       end
       task.add_description "Load the seed data from #{seed_file}"
       task.name

--- a/lib/seedbank/dsl.rb
+++ b/lib/seedbank/dsl.rb
@@ -12,7 +12,7 @@ module Seedbank
 
     def seed_task_from_file(seed_file)
       scopes  = scope_from_seed_file(seed_file)
-      fq_name = scopes.push(File.basename(seed_file, '.seeds.rb')).join(':')
+      fq_name = scopes.push(File.basename(seed_file, '_seeds.rb')).join(':')
       args    = Rake::Task.task_defined?('db:abort_if_pending_migrations') ? { fq_name => 'db:abort_if_pending_migrations' } : fq_name
 
       define_seed_task(seed_file, args)

--- a/lib/seedbank/runner.rb
+++ b/lib/seedbank/runner.rb
@@ -15,10 +15,10 @@ module Seedbank
     # If no block is specified just the dependencies are run. This makes it possible
     # to create shared dependencies. For example
     #
-    # @example db/seeds/production/users.seeds.rb
+    # @example db/seeds/production/users_seeds.rb
     #   after 'shared:users'
     #
-    # Would look for a db/seeds/shared/users.seeds.rb seed and execute it.
+    # Would look for a db/seeds/shared/users_seeds.rb seed and execute it.
     def after(*dependencies, &block)
       dependencies.flatten!
       dependencies.map! { |dep| "db:seed:#{dep}"}

--- a/lib/seedbank/version.rb
+++ b/lib/seedbank/version.rb
@@ -1,3 +1,3 @@
 module Seedbank
-  VERSION = "0.2.0"
+  VERSION = "0.2.1"
 end

--- a/lib/tasks/seed.rake
+++ b/lib/tasks/seed.rake
@@ -8,9 +8,9 @@ namespace :db do
   namespace :seed do
     # Create seed tasks for all the seeds in seeds_path and add them to the dependency
     # list along with the original db/seeds.rb.
-    common_dependencies = glob_seed_files_matching('*.seeds.rb').map { |seed_file| seed_task_from_file(seed_file) }
+    common_dependencies = glob_seed_files_matching('*_seeds.rb').map { |seed_file| seed_task_from_file(seed_file) }
 
-    desc "Load the seed data from db/seeds.rb and db/seeds/*.seeds.rb."
+    desc "Load the seed data from db/seeds.rb and db/seeds/*_seeds.rb."
     task 'common' => base_dependencies + common_dependencies
 
     # Glob through the directories under seeds_path and create a task for each adding it to the dependency list.
@@ -18,9 +18,9 @@ namespace :db do
     glob_seed_files_matching('/*/').each do |directory|
       environment = File.basename(directory)
 
-      environment_dependencies = glob_seed_files_matching(environment, '*.seeds.rb').sort.map { |seed_file| seed_task_from_file(seed_file) }
+      environment_dependencies = glob_seed_files_matching(environment, '*_seeds.rb').sort.map { |seed_file| seed_task_from_file(seed_file) }
 
-      desc "Load the seed data from db/seeds.rb, db/seeds/*.seeds.rb and db/seeds/#{environment}/*.seeds.rb."
+      desc "Load the seed data from db/seeds.rb, db/seeds/*_seeds.rb and db/seeds/#{environment}/*_seeds.rb."
       task environment => ['db:seed:common'] + environment_dependencies
 
       override_dependency << "db:seed:#{environment}" if defined?(Rails) && Rails.env == environment
@@ -28,7 +28,7 @@ namespace :db do
   end
 
   # Override db:seed to run all the common and environments seeds plus the original db:seed.
-  desc "Load the seed data from db/seeds.rb, db/seeds/*.seeds.rb and db/seeds/ENVIRONMENT/*.seeds.rb. ENVIRONMENT is the current environment in Rails.env."
+  desc "Load the seed data from db/seeds.rb, db/seeds/*_seeds.rb and db/seeds/ENVIRONMENT/*_seeds.rb. ENVIRONMENT is the current environment in Rails.env."
   override_seed_task :seed => override_dependency
 
 end

--- a/lib/tasks/seed.rake
+++ b/lib/tasks/seed.rake
@@ -8,7 +8,7 @@ namespace :db do
   namespace :seed do
     # Create seed tasks for all the seeds in seeds_path and add them to the dependency
     # list along with the original db/seeds.rb.
-    common_dependencies = glob_seed_files_matching('*_seeds.rb').map { |seed_file| seed_task_from_file(seed_file) }
+    common_dependencies = glob_seed_files_matching('*_seeds.rb').sort.map { |seed_file| seed_task_from_file(seed_file) }
 
     desc "Load the seed data from db/seeds.rb and db/seeds/*_seeds.rb."
     task 'common' => base_dependencies + common_dependencies

--- a/seedbank.gemspec
+++ b/seedbank.gemspec
@@ -33,9 +33,9 @@ Gem::Specification.new do |s|
     "README.md"
   ]
 
-  s.add_development_dependency "minitest", "~> 3.2"
+  s.add_development_dependency "minitest", ">= 3.2"
   s.add_development_dependency "flexmock"
-  s.add_development_dependency "rails", "~> 3.2.6"
+  s.add_development_dependency "rails", ">= 3.2.6"
   
   s.post_install_message = %q{
   ================================================================================

--- a/test/dummy/db/seeds/circular1_seeds.rb
+++ b/test/dummy/db/seeds/circular1_seeds.rb
@@ -1,0 +1,3 @@
+after :circular2 do
+  FakeModel.seed('circular1')
+end

--- a/test/dummy/db/seeds/circular2_seeds.rb
+++ b/test/dummy/db/seeds/circular2_seeds.rb
@@ -1,0 +1,3 @@
+after :circular1 do
+  FakeModel.seed('circular2')
+end

--- a/test/dummy/db/seeds/dependency2_seeds.rb
+++ b/test/dummy/db/seeds/dependency2_seeds.rb
@@ -1,0 +1,1 @@
+FakeModel.seed('dependency2')

--- a/test/dummy/db/seeds/dependency_seeds.rb
+++ b/test/dummy/db/seeds/dependency_seeds.rb
@@ -1,0 +1,1 @@
+FakeModel.seed('dependency')

--- a/test/dummy/db/seeds/dependent_on_nested_seeds.rb
+++ b/test/dummy/db/seeds/dependent_on_nested_seeds.rb
@@ -1,0 +1,3 @@
+after :dependent, :dependency2 do
+  FakeModel.seed('dependent on nested')
+end

--- a/test/dummy/db/seeds/dependent_on_several_seeds.rb
+++ b/test/dummy/db/seeds/dependent_on_several_seeds.rb
@@ -1,0 +1,3 @@
+after :dependency, :dependency2 do
+  FakeModel.seed('dependent on several')
+end

--- a/test/dummy/db/seeds/dependent_seeds.rb
+++ b/test/dummy/db/seeds/dependent_seeds.rb
@@ -1,0 +1,3 @@
+after :dependency do
+  FakeModel.seed('dependent')
+end

--- a/test/dummy/db/seeds/development/users_seeds.rb
+++ b/test/dummy/db/seeds/development/users_seeds.rb
@@ -1,0 +1,1 @@
+FakeModel.seed('development:users')

--- a/test/dummy/db/seeds/no_block_seeds.rb
+++ b/test/dummy/db/seeds/no_block_seeds.rb
@@ -1,0 +1,1 @@
+after :dependency

--- a/test/lib/seedbank/dsl_test.rb
+++ b/test/lib/seedbank/dsl_test.rb
@@ -12,7 +12,7 @@ describe Seedbank::DSL do
 
     describe "in an environment directory" do
 
-      let(:seed_file) { File.expand_path('development/users.seeds.rb', Seedbank.seeds_root) }
+      let(:seed_file) { File.expand_path('development/users_seeds.rb', Seedbank.seeds_root) }
       let(:seed_namespace) { %w(development) }
 
       subject { Seedbank::DSL.scope_from_seed_file seed_file }
@@ -24,7 +24,7 @@ describe Seedbank::DSL do
 
     describe "in a nested directory" do
 
-      let(:seed_file) { File.expand_path('development/shared/accounts.seeds.rb', Seedbank.seeds_root) }
+      let(:seed_file) { File.expand_path('development/shared/accounts_seeds.rb', Seedbank.seeds_root) }
       let(:seed_namespace) { %w(development shared) }
 
       subject { Seedbank::DSL.scope_from_seed_file seed_file }
@@ -36,7 +36,7 @@ describe Seedbank::DSL do
 
     describe "in seeds root" do
 
-      let(:seed_file) { File.expand_path('no_block.seeds.rb', Seedbank.seeds_root) }
+      let(:seed_file) { File.expand_path('no_block_seeds.rb', Seedbank.seeds_root) }
 
       subject { Seedbank::DSL.scope_from_seed_file seed_file }
 
@@ -68,7 +68,7 @@ describe Seedbank::DSL do
 
     describe "with no namespace" do
 
-      let(:pattern) { '*.seeds.rb' }
+      let(:pattern) { '*_seeds.rb' }
 
       it "returns all the files matching the pattern in seeds_root" do
         expected_files = Dir.glob(File.join(Seedbank.seeds_root, pattern))
@@ -80,7 +80,7 @@ describe Seedbank::DSL do
 
     describe "with a namespace" do
 
-      let(:pattern) { '*.seeds.rb' }
+      let(:pattern) { '*_seeds.rb' }
       let(:namespace) { 'development' }
 
       it "returns all the files matching the pattern in seeds_root" do
@@ -97,7 +97,7 @@ describe Seedbank::DSL do
 
     let(:name) { 'scoped:my_seed' }
     let(:dependencies) { ['environment'] }
-    let(:seed_file) { File.expand_path('development/users.seeds.rb', Seedbank.seeds_root) }
+    let(:seed_file) { File.expand_path('development/users_seeds.rb', Seedbank.seeds_root) }
 
     it "returns a fully qualified task name" do
       returned_name = Seedbank::DSL.define_seed_task(seed_file, name => dependencies)

--- a/test/lib/tasks/seed_rake_test.rb
+++ b/test/lib/tasks/seed_rake_test.rb
@@ -17,8 +17,8 @@ describe 'Seedbank rake.task' do
 
   describe "common seeds in the root directory" do
 
-    Dir[File.expand_path('../../../dummy/db/seeds/*.seeds.rb', __FILE__)].each do |seed_file|
-      seed = File.basename(seed_file, '.seeds.rb')
+    Dir[File.expand_path('../../../dummy/db/seeds/*_seeds.rb', __FILE__)].each do |seed_file|
+      seed = File.basename(seed_file, '_seeds.rb')
 
       describe seed do
 
@@ -36,8 +36,8 @@ describe 'Seedbank rake.task' do
     subject { Rake::Task['db:seed:common'] }
 
     it "is dependent on the common seeds and db:seed:original" do
-      prerequisite_seeds = Dir[File.expand_path('../../../dummy/db/seeds/*.seeds.rb', __FILE__)].map do |seed_file|
-        ['db', 'seed', File.basename(seed_file, '.seeds.rb')].join(':')
+      prerequisite_seeds = Dir[File.expand_path('../../../dummy/db/seeds/*_seeds.rb', __FILE__)].map do |seed_file|
+        ['db', 'seed', File.basename(seed_file, '_seeds.rb')].join(':')
       end.unshift('db:seed:original')
 
       subject.prerequisites.must_equal prerequisite_seeds
@@ -71,8 +71,8 @@ describe 'Seedbank rake.task' do
 
       describe "seeds in the #{environment} environment" do
 
-        Dir[File.expand_path("../../../dummy/db/seeds/#{environment}/*.seeds.rb", __FILE__)].each do |seed_file|
-          seed = File.basename(seed_file, '.seeds.rb')
+        Dir[File.expand_path("../../../dummy/db/seeds/#{environment}/*_seeds.rb", __FILE__)].each do |seed_file|
+          seed = File.basename(seed_file, '_seeds.rb')
 
           describe seed do
 
@@ -90,8 +90,8 @@ describe 'Seedbank rake.task' do
         subject { Rake.application.lookup(environment, %w[db seed]) }
 
         it "is dependent on the seeds in the environment directory" do
-          prerequisite_seeds = Dir[File.expand_path("../../../dummy/db/seeds/#{environment}/*.seeds.rb", __FILE__)].map do |seed_file|
-            ['db', 'seed', environment, File.basename(seed_file, '.seeds.rb')].join(':')
+          prerequisite_seeds = Dir[File.expand_path("../../../dummy/db/seeds/#{environment}/*_seeds.rb", __FILE__)].map do |seed_file|
+            ['db', 'seed', environment, File.basename(seed_file, '_seeds.rb')].join(':')
           end.unshift('db:seed:common')
 
           subject.prerequisites.must_equal prerequisite_seeds


### PR DESCRIPTION
I'm submitting this pull request in reference to my comment https://github.com/james2m/seedbank/issues/13#issuecomment-9907474

This pull will require users to rename their seeds files.

To me, this naming is synonymous with the other file naming conventions in Rails.

The word "seed" in the English language can denote singular or plural noun. The word "seed" also denotes action. I decided to keep with the plural `_seeds.rb` as it can express one or more individual seeds and help differentiate between noun and verb. Perhaps in a future version of Seedbank, it can detect `_seeds.rb` and `_seed.rb`.