### PR TITLE
Add license reference for license audit tools

### DIFF
--- a/seedbank.gemspec
+++ b/seedbank.gemspec
@@ -9,6 +9,7 @@ Gem::Specification.new do |s|
 
   s.required_rubygems_version = Gem::Requirement.new(">=1.2.0") if s.respond_to?(:required_rubygems_version=)
   s.rubygems_version = %q{1.3.5}
+  s.license = "MIT"
 
   s.authors = ["James McCarthy"]
   s.email = %q{james2mccarthy@gmail.com}


### PR DESCRIPTION
We're currently using http://licenseaudit.pivotallabs.com/ to audit the licenses in our dependencies. Having it in the gemspec makes it easy for the tool to pick up that it's approved
