### PR TITLE
Allow reinvoking seed tasks

### DIFF
--- a/lib/seedbank/runner.rb
+++ b/lib/seedbank/runner.rb
@@ -23,7 +23,13 @@ module Seedbank
       dependencies.flatten!
       dependencies.map! { |dep| "db:seed:#{dep}"}
       dependent_task_name =  @task.name + ':body'
-      dependent_task = Rake::Task.define_task(dependent_task_name => dependencies, &block)
+
+      # Only define the dependent task the first time through
+      dependent_task = Rake.application.lookup(dependent_task_name)
+      unless dependent_task
+        dependent_task = Rake::Task.define_task(dependent_task_name => dependencies, &block)
+      end
+
       dependent_task.invoke
     end
   

--- a/test/lib/seedbank/runner_test.rb
+++ b/test/lib/seedbank/runner_test.rb
@@ -16,6 +16,16 @@ describe Seedbank::Runner do
 
       subject.invoke
     end
+
+    it "executes the body of the dependencies exactly once per invocation" do
+      FakeModel.should_receive(:seed).with('dependency').twice
+      FakeModel.should_receive(:seed).with('dependent').twice
+
+      subject.invoke
+      # Allow all tasks to be re-executed, including dependencies
+      Rake.application.tasks.each { |t| t.reenable }
+      subject.invoke
+    end
   end
 
   describe "seeds with multiple dependencies" do


### PR DESCRIPTION
Rake allows a task to be "reenabled" to run more than once in the same overall rake process. Prior to this commit, if you attempted to reinvoke a seedbank task, the task expressing its dependencies would be redefined. The effect of that redefinition was that the seed data code would effectively run twice on the second invocation, three times on the third, etc.

Reinvoking seed tasks can be useful within a test suite. It allows you to define real seed data for just the tests that need it, avoiding overhead and the complications of a non-empty database for tests that don't need the seed data.
