### PR TITLE
Ruby 2.0 is no longer supported

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: ruby
 
 rvm:
-  - 2.0
   - 2.1
   - 2.2
   - 2.3.1


### PR DESCRIPTION
Ruby 2.0 support seems to be [ended](https://www.ruby-lang.org/en/news/2016/02/24/support-plan-of-ruby-2-0-0-and-2-1/).
It [fails](https://travis-ci.org/james2m/seedbank/jobs/192011049) specs.