### PR TITLE
Add rake task to setup DB layer for non-rails deployments

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,29 @@ That's it!
 
 ### Non Rails apps
 
-Although originally built for Rails, Seedbank should work fine in other environments such as Padrino, Grape or the new new hotness. please let us know how you get on.
+Although originally built for Rails, Seedbank should work fine in other environments such as Padrino, Grape or the new new hotness.
+
+Add the seedbank gem to your Gemfile.  In Gemfile:
+
+```ruby
+gem "seedbank"
+```
+
+In your Rakefile create a `db:seed:setup` task that configures your database layer before the seed files are executed.
+
+The example below is for an application using DRY-rb and ROM to provide database access, your setup will probably be different. In Rakefile:
+
+```ruby
+namespace :db do
+  namespace :seed do
+    task :setup do
+      # require our DRY container and boot our repositories
+      require 'container'
+      Application.boot!(:repository)
+    end
+  end
+end
+```
 
 ### Rails 3.x
 

--- a/lib/tasks/seed.rake
+++ b/lib/tasks/seed.rake
@@ -4,6 +4,10 @@ namespace :db do
   override_dependency = ['db:seed:common']
 
   namespace :seed do
+    task :setup do
+      # override in your Rakefile for your own DB backend setup
+    end
+
     # Create seed tasks for all the seeds in seeds_path and add them to the dependency
     # list along with the original db/seeds.rb.
     common_dependencies = seed_tasks_matching(Seedbank.matcher)
@@ -15,7 +19,7 @@ namespace :db do
     end
 
     desc "Load the seed data from db/seeds.rb and db/seeds/#{Seedbank.matcher}."
-    task 'common' => common_dependencies
+    task 'common' => ['db:seed:setup'] + common_dependencies
 
     # Glob through the directories under seeds_path and create a task for each adding it to the dependency list.
     # Then create a task for the environment
@@ -25,7 +29,7 @@ namespace :db do
       environment_dependencies = seed_tasks_matching(environment, Seedbank.matcher)
 
       desc "Load the seed data from db/seeds.rb, db/seeds/#{Seedbank.matcher} and db/seeds/#{environment}/#{Seedbank.matcher}."
-      task environment => ['db:seed:common'] + environment_dependencies
+      task environment => ['db:seed:setup', 'db:seed:common'] + environment_dependencies
 
       override_dependency << "db:seed:#{environment}" if defined?(Rails) && Rails.env == environment
     end


### PR DESCRIPTION
Add a new rake task to set up db layers for non-rails setups and update README to provide at least one example of this.