### PR TITLE
Add configurable before_each and after_each

### DIFF
--- a/lib/seedbank.rb
+++ b/lib/seedbank.rb
@@ -1,8 +1,11 @@
 # frozen_string_literal: true
+require 'seedbank/configuration'
 require 'seedbank/dsl'
 require 'seedbank/runner'
 
 module Seedbank
+  extend Configuration
+
   class << self
     attr_writer :application_root, :seeds_root, :nesting, :matcher
 

--- a/lib/seedbank/configuration.rb
+++ b/lib/seedbank/configuration.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Seedbank
   module Configuration
     # Start a Seedbank configuration block in an initializer.

--- a/lib/seedbank/configuration.rb
+++ b/lib/seedbank/configuration.rb
@@ -1,0 +1,21 @@
+module Seedbank
+  module Configuration
+    # Start a Seedbank configuration block in an initializer.
+    #
+    # example: Provide before and after lambdas
+    #   Seedbank.configure do |config|
+    #     config.before = lambda do
+    #       ...
+    #     end
+    #   end
+    def configure
+      yield self
+    end
+
+    mattr_accessor :before_each
+    @before_each = nil
+
+    mattr_accessor :after_each
+    @after_each = nil
+  end
+end

--- a/lib/seedbank/runner.rb
+++ b/lib/seedbank/runner.rb
@@ -48,7 +48,12 @@ module Seedbank
 
     def evaluate(seed_task, seed_file)
       @_seed_task = seed_task
-      instance_eval(File.read(seed_file), seed_file)
+      Configuration.before_each.call if Configuration.before_each
+      begin
+        instance_eval(File.read(seed_file), seed_file)
+      ensure
+        Configuration.after_each.call if Configuration.after_each
+      end
     end
   end
 end

--- a/seedbank.gemspec
+++ b/seedbank.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |spec|
   spec.version     = Seedbank::VERSION
   spec.authors     = ['James McCarthy']
   spec.email       = ['[james2mccarthy@gmail.com']
-  spec.required_ruby_version = '>= 2.1'
+  spec.required_ruby_version = '>= 2.7'
   spec.summary     = 'Generate seeds data for your Ruby application.'
   spec.description = %(
     Adds simple rake commands for seeding your database. Simple dependencies let you organise your seeds.
@@ -30,9 +30,9 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'rake', '>= 10.0'
 
-  spec.add_development_dependency 'bundler',  '~> 1.11'
-  spec.add_development_dependency 'rails',    '~> 4.2'
+  spec.add_development_dependency 'bundler',  '~> 2.4.2'
+  spec.add_development_dependency 'rails',    '>= 7.0 '
   spec.add_development_dependency 'minitest', '~> 5.0'
   spec.add_development_dependency 'm',        '~> 1.5'
-  spec.add_development_dependency 'byebug',   '~> 9.0'
+  spec.add_development_dependency 'byebug',   '~> 11.1'
 end

--- a/test/dummy/config/initializers/seedbank.rb
+++ b/test/dummy/config/initializers/seedbank.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require 'seedbank'
+
+Seedbank.configure do |config|
+  config.before_each = lambda do
+    BeforeEachCalls << '.'
+  end
+
+  config.after_each = lambda do
+    AfterEachCalls << '.'
+  end
+end

--- a/test/lib/seedbank/runner_test.rb
+++ b/test/lib/seedbank/runner_test.rb
@@ -150,4 +150,18 @@ describe Seedbank::Runner do
       end
     end
   end
+
+  describe 'calling before and after hooks' do
+    subject { Rake::Task['db:seed:dependent'] }
+
+    it 'executes the configured lambdas' do
+      FakeModel.expect :seed, true, ['dependency']
+      FakeModel.expect :seed, true, ['dependent']
+
+      subject.invoke
+
+      BeforeEachCalls.length.must_equal 2
+      AfterEachCalls.length.must_equal 2
+    end
+  end
 end

--- a/test/lib/tasks/seed_rake_test.rb
+++ b/test/lib/tasks/seed_rake_test.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require 'test_helper'
+require_relative '../../test_helper'
 using Seedbank::DSL
 
 describe 'Seedbank rake.task' do
@@ -21,7 +21,7 @@ describe 'Seedbank rake.task' do
     it 'creates all the seed tasks' do
       seeds = %w[db:seed:circular1 db:seed:circular2 db:seed:common db:seed:dependency db:seed:dependency2
                  db:seed:dependent db:seed:dependent_on_nested db:seed:dependent_on_several db:seed:development
-                 db:seed:development:users db:seed:no_block db:seed:original db:seed:reference_memos db:seed:with_block_memo db:seed:with_inline_memo]
+                 db:seed:development:users db:seed:no_block db:seed:original db:seed:reference_memos db:seed:replant db:seed:with_block_memo db:seed:with_inline_memo]
 
       subject.map(&:to_s).must_equal seeds
     end
@@ -58,7 +58,7 @@ describe 'Seedbank rake.task' do
       def setup
         main = TOPLEVEL_BINDING.eval('class << self; self; end')
         orig = original_seeds_file
-        main.send(:undef_method, :original_seeds_file) if main.respond_to?(:original_seeds_file, true)
+        main.send(:undef_method, :original_seeds_file) if main.method_defined?(:original_seeds_file)
         main.send(:define_method, :original_seeds_file) { nil }
         super
         main.send(:undef_method, :original_seeds_file)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -12,12 +12,12 @@ Rails.backtrace_cleaner.remove_silencers!
 
 Seedbank.application_root = Pathname.new(File.expand_path('../dummy', __FILE__))
 
-class Seedbank::Spec < MiniTest::Spec
+class Seedbank::Spec < Minitest::Spec
   def setup
     silence_warnings do
       Rake.application = Rake::Application.new
       Dummy::Application.load_tasks
-      Object.const_set :FakeModel, MiniTest::Mock.new
+      Object.const_set :FakeModel, Minitest::Mock.new
       Object.const_set :BeforeEachCalls, []
       Object.const_set :AfterEachCalls, []
       TOPLEVEL_BINDING.eval('self').send(:instance_variable_set, :@_seedbank_runner, Seedbank::Runner.new)
@@ -27,5 +27,5 @@ class Seedbank::Spec < MiniTest::Spec
   end
 end
 
-MiniTest::Spec.register_spec_type(/^Seedbank/i, Seedbank::Spec)
-MiniTest.autorun
+Minitest::Spec.register_spec_type(/^Seedbank/i, Seedbank::Spec)
+Minitest.autorun

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -18,6 +18,8 @@ class Seedbank::Spec < MiniTest::Spec
       Rake.application = Rake::Application.new
       Dummy::Application.load_tasks
       Object.const_set :FakeModel, MiniTest::Mock.new
+      Object.const_set :BeforeEachCalls, []
+      Object.const_set :AfterEachCalls, []
       TOPLEVEL_BINDING.eval('self').send(:instance_variable_set, :@_seedbank_runner, Seedbank::Runner.new)
     end
 


### PR DESCRIPTION
This PR allows to add a configuration file to seedbank in order to define 2 lambdas, before_each and after_each, executed before and after every seed file.
Those lambdas can help set and clean up any particular state that depends on file system, redis, etc.