### PR TITLE
Test against Rake 12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ rvm:
 gemfile:
   - gemfiles/rake10.gemfile
   - gemfiles/rake11.gemfile
+  - gemfiles/rake12.gemfile
 
 before_install:
   - gem install bundler -v '~> 1.11' --no-ri --no-rdoc

--- a/gemfiles/rake10.gemfile
+++ b/gemfiles/rake10.gemfile
@@ -7,7 +7,3 @@ gem 'rake', '~>10.0', :group => :test
 
 # for CRuby, Rubinius, including Windows and RubyInstaller
 gem "sqlite3", :platform => [:ruby, :mswin, :mingw]
-
-# for JRuby
-gem 'activerecord-jdbcsqlite3-adapter', :platform => :jruby
-

--- a/gemfiles/rake11.gemfile
+++ b/gemfiles/rake11.gemfile
@@ -7,7 +7,3 @@ gem 'rake', '~>11.0', :group => :test
 
 # for CRuby, Rubinius, including Windows and RubyInstaller
 gem "sqlite3", :platform => [:ruby, :mswin, :mingw]
-
-# for JRuby
-gem 'activerecord-jdbcsqlite3-adapter', :platform => :jruby
-

--- a/gemfiles/rake12.gemfile
+++ b/gemfiles/rake12.gemfile
@@ -1,0 +1,13 @@
+source "http://rubygems.org"
+
+# Specify your gem's dependencies in seedbank.gemspec
+gemspec :path=>"../"
+
+gem 'rake', '~>12.0', :group => :test
+
+# for CRuby, Rubinius, including Windows and RubyInstaller
+gem "sqlite3", :platform => [:ruby, :mswin, :mingw]
+
+# for JRuby
+gem 'activerecord-jdbcsqlite3-adapter', :platform => :jruby
+

--- a/gemfiles/rake12.gemfile
+++ b/gemfiles/rake12.gemfile
@@ -7,7 +7,3 @@ gem 'rake', '~>12.0', :group => :test
 
 # for CRuby, Rubinius, including Windows and RubyInstaller
 gem "sqlite3", :platform => [:ruby, :mswin, :mingw]
-
-# for JRuby
-gem 'activerecord-jdbcsqlite3-adapter', :platform => :jruby
-


### PR DESCRIPTION
# Problem

README says it's not updated for Rails 5 but it works.
I'd like to use `seedbank` for my Rails 5.2 project but it's not tested against Rake 12, which is likely to be used for Rails 5.2 projects.

# Solution

I added Rake 12 to `gemfiles` directory.

## Pros

- It makes it more likely that `seedbank` works well with Rails 5.2

## Cons

- It makes test suites run more slowly