### PR TITLE
Add Ruby 2.4.4 and 2.5.1 to `.travis.yml`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ rvm:
   - 2.1
   - 2.2
   - 2.3.1
+  - 2.4.4
+  - 2.5.1
 
 gemfile:
   - gemfiles/rake10.gemfile


### PR DESCRIPTION
# Problem

The gem isn't tested against latest rubies.

# Solution

Added Ruby `2.4.4` and `2.5.1` to `.travis.yml`.