### PR TITLE
Fix settings of Rubocop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,5 @@
 inherit_from: .rubocop_todo.yml
-Style/StringLiteral:
+Style/StringLiterals:
   Enabled: true
   EnforcedStyle: single_quotes
 Style/MutableConstant:


### PR DESCRIPTION
See https://rubocop.readthedocs.io/en/latest/cops_style/#stylestringliterals

The valid key is not 'Style/StringLiteral' but 'Style/StringLiteral**s**'.

Before fixing, an error raises like this
```
Warning: unrecognized cop Style/StringLiteral found in .rubocop.yml
```

So I fixed it.
